### PR TITLE
Correção de bug ao ativar um plugin necessário

### DIFF
--- a/includes/admin/views/html-notice-missing-soap-client.php
+++ b/includes/admin/views/html-notice-missing-soap-client.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Missing dependencies notice.
  *
@@ -8,9 +7,9 @@
  * @version  1.0.1
  */
 
-// Exit if accessed directly
+// Exit if accessed directly.
 defined( 'ABSPATH' ) || exit; ?>
 
 <div class="error">
-	<p><strong><?php _e( 'The WooCommerce NFe plugin', 'woo-nfe' ); ?></strong> <?php printf( __( 'needs the %s to work!', 'woo-nfe' ), '<a href="https://secure.php.net/manual/en/class.soapclient.php" target="_blank">' . __( 'SOAP module', 'woo-nfe' ) . '</a>' ); ?></p>
+	<p><strong><?php esc_html_e( 'The WooCommerce NFe plugin', 'woo-nfe' ); ?></strong> <?php printf( __( 'needs the %s to work!', 'woo-nfe' ), '<a href="https://secure.php.net/manual/en/class.soapclient.php" target="_blank">' . __( 'SOAP module', 'woo-nfe' ) . '</a>' ); ?></p>
 </div>

--- a/includes/admin/views/html-notice-missing-woocommerce-extra-checkout-fields.php
+++ b/includes/admin/views/html-notice-missing-woocommerce-extra-checkout-fields.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Missing dependencies notice.
  *
@@ -8,7 +7,7 @@
  * @version  1.0.1
  */
 
-// Exit if accessed directly
+// Exit if accessed directly.
 defined( 'ABSPATH' ) || exit;
 
 $is_installed = false;
@@ -20,18 +19,24 @@ if ( function_exists( 'get_plugins' ) ) {
 ?>
 
 <div class="error">
-	<p><strong><?php esc_html_e( 'WooCommerce Nfe.io', 'woo-nfe' ); ?></strong> <?php esc_html_e( 'depends on the last version of WooCommerce Extra Checkout Fields for Brazil to work!', 'woo-nfe' ); ?></p>
+	<p><strong><?php esc_html_e( 'WooCommerce NFe.io', 'woo-nfe' ); ?></strong> <?php esc_html_e( 'depends on the lastest version of WooCommerce Extra Checkout Fields for Brazil to work!', 'woo-nfe' ); ?></p>
 
-	<?php if ( $is_installed && current_user_can( 'install_plugins' ) ) : ?>
-		<p><a href="<?php echo esc_url( wp_nonce_url( self_admin_url( 'plugins.php?action=activate&plugin=woocommerce-extra-checkout-fields-for-brazil/woocommerce-extra-checkout-fields-for-brazil.php&plugin_status=active' ), 'activate-plugin_woocommerce_checkout_fields/woocommerce-extra-checkout-fields-for-brazil.php' ) ); ?>" class="button button-primary"><?php esc_html_e( 'Active WooCommerce Extra Checkout Fields for Brazil', 'woo-nfe' ); ?></a></p>
-	<?php else : ?>
+	<?php if ( $is_installed && current_user_can( 'activate_plugin' ) ) : ?>
+		<p>
+			<a href="<?php echo esc_url( wp_nonce_url( 'plugins.php?action=activate&amp;plugin=woocommerce-extra-checkout-fields-for-brazil/woocommerce-extra-checkout-fields-for-brazil.php&amp;plugin_status=all', 'activate-plugin_woocommerce-extra-checkout-fields-for-brazil/woocommerce-extra-checkout-fields-for-brazil.php' ) ); ?>" class="button button-primary">
+				<?php esc_html_e( 'Active WooCommerce Extra Checkout Fields for Brazil', 'woo-nfe' ); ?>
+			</a>
+		</p>
 	<?php
-	if ( current_user_can( 'install_plugins' ) ) {
-		$url = wp_nonce_url( self_admin_url( 'update.php?action=install-plugin&plugin=woocommerce-extra-checkout-fields-for-brazil' ), 'install-plugin_woocommerce_checkout_fields' );
-	} else {
-		$url = 'https://wordpress.org/plugins/woocommerce-extra-checkout-fields-for-brazil/';
-	}
-	?>
-		<p><a href="<?php echo esc_url( $url ); ?>" class="button button-primary"><?php esc_html_e( 'Install WooCommerce Extra Checkout Fields for Brazil', 'woo-nfe' ); ?></a></p>
+	else :
+		if ( current_user_can( 'install_plugins' ) ) {
+			$url = wp_nonce_url( self_admin_url( 'update.php?action=install-plugin&plugin=woocommerce-extra-checkout-fields-for-brazil' ), 'install-plugin_woocommerce_checkout_fields' );
+		} else {
+			$url = 'https://wordpress.org/plugins/woocommerce-extra-checkout-fields-for-brazil/';
+		}
+		?>
+		<p><a href="<?php echo esc_url( $url ); ?>" class="button button-primary">
+			<?php esc_html_e( 'Install WooCommerce Extra Checkout Fields for Brazil', 'woo-nfe' ); ?></a>
+		</p>
 	<?php endif; ?>
 </div>

--- a/includes/admin/views/html-notice-missing-woocommerce.php
+++ b/includes/admin/views/html-notice-missing-woocommerce.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Missing dependencies notice.
  *
@@ -8,7 +7,7 @@
  * @version  1.0.1
  */
 
-// Exit if accessed directly
+// Exit if accessed directly.
 defined( 'ABSPATH' ) || exit;
 
 $is_installed = false;
@@ -20,18 +19,24 @@ if ( function_exists( 'get_plugins' ) ) {
 ?>
 
 <div class="error">
-	<p><strong><?php esc_html_e( 'WooCommerce Nfe.io', 'woo-nfe' ); ?></strong> <?php esc_html_e( 'depends on the last version of WooCommerce to work!', 'woo-nfe' ); ?></p>
+	<p><strong><?php esc_html_e( 'WooCommerce NFe.io', 'woo-nfe' ); ?></strong> <?php esc_html_e( 'depends on the last version of WooCommerce to work!', 'woo-nfe' ); ?></p>
 
-	<?php if ( $is_installed && current_user_can( 'install_plugins' ) ) : ?>
-		<p><a href="<?php echo esc_url( wp_nonce_url( self_admin_url( 'plugins.php?action=activate&plugin=woocommerce/woocommerce.php&plugin_status=active' ), 'activate-plugin_woocommerce/woocommerce.php' ) ); ?>" class="button button-primary"><?php esc_html_e( 'Active WooCommerce', 'woo-nfe' ); ?></a></p>
-	<?php else : ?>
+	<?php if ( $is_installed && current_user_can( 'activate_plugin' ) ) : ?>
+		<p>
+			<a href="<?php echo esc_url( wp_nonce_url( self_admin_url( 'plugins.php?action=activate&plugin=woocommerce/woocommerce.php&plugin_status=active' ), 'activate-plugin_woocommerce/woocommerce.php' ) ); ?>" class="button button-primary">
+				<?php esc_html_e( 'Active WooCommerce', 'woo-nfe' ); ?>
+			</a>
+		</p>
 	<?php
-	if ( current_user_can( 'install_plugins' ) ) {
-		$url = wp_nonce_url( self_admin_url( 'update.php?action=install-plugin&plugin=woocommerce' ), 'install-plugin_woocommerce' );
-	} else {
-		$url = 'https://wordpress.org/plugins/woocommerce/';
-	}
-	?>
-		<p><a href="<?php echo esc_url( $url ); ?>" class="button button-primary"><?php esc_html_e( 'Install WooCommerce', 'woo-nfe' ); ?></a></p>
+	else :
+		if ( current_user_can( 'install_plugins' ) ) {
+			$url = wp_nonce_url( self_admin_url( 'update.php?action=install-plugin&plugin=woocommerce' ), 'install-plugin_woocommerce' );
+		} else {
+			$url = 'https://wordpress.org/plugins/woocommerce/';
+		}
+		?>
+		<p><a href="<?php echo esc_url( $url ); ?>" class="button button-primary">
+			<?php esc_html_e( 'Install WooCommerce', 'woo-nfe' ); ?></a>
+		</p>
 	<?php endif; ?>
 </div>


### PR DESCRIPTION
Fixes #10 

Essa PR corrigi um erro ao tentar instalar um plugin que o NFe precisa.

Estado quando o plugin está desativado.

![activate-plugin](https://user-images.githubusercontent.com/19148962/36634389-8e9250e0-1982-11e8-8ab0-9d851bf1f0ab.jpg)

Clicando no botão, ativa o plugin. Isso em qualquer página do painel do WordPress.

![plugin-activated](https://user-images.githubusercontent.com/19148962/36634390-a1a2a586-1982-11e8-85b3-93db62b2685f.jpg)

