### PR TITLE
feat(rtc): adiciona suporte ao grupo activityEvent no payload NFS-e

### DIFF
--- a/includes/admin/class-admin.php
+++ b/includes/admin/class-admin.php
@@ -235,6 +235,127 @@ if ( ! class_exists( 'WC_NFe_Admin' ) ) {
 					)
 				);
 
+				woocommerce_wp_text_input(
+					array(
+						'id'            => '_simple_nfe_activity_event_name',
+						'label'         => __( 'Event name (activityEvent.name)', 'woo-nfe' ),
+						'wrapper_class' => 'hide_if_variable',
+						'desc_tip'      => 'true',
+						'description'   => __( 'Name of the activity event. When filled, the activityEvent block will be included in the invoice payload.', 'woo-nfe' ),
+						'value'         => get_post_meta( $post_id, '_simple_nfe_activity_event_name', true ),
+					)
+				);
+
+				woocommerce_wp_text_input(
+					array(
+						'id'            => '_simple_nfe_activity_event_begin_on',
+						'label'         => __( 'Event start (activityEvent.beginOn)', 'woo-nfe' ),
+						'wrapper_class' => 'hide_if_variable',
+						'desc_tip'      => 'true',
+						'description'   => __( 'Start date/time of the activity event (ISO 8601, e.g. 2025-07-01T09:00:00).', 'woo-nfe' ),
+						'value'         => get_post_meta( $post_id, '_simple_nfe_activity_event_begin_on', true ),
+					)
+				);
+
+				woocommerce_wp_text_input(
+					array(
+						'id'            => '_simple_nfe_activity_event_end_on',
+						'label'         => __( 'Event end (activityEvent.endOn)', 'woo-nfe' ),
+						'wrapper_class' => 'hide_if_variable',
+						'desc_tip'      => 'true',
+						'description'   => __( 'End date/time of the activity event (ISO 8601, e.g. 2025-07-01T18:00:00).', 'woo-nfe' ),
+						'value'         => get_post_meta( $post_id, '_simple_nfe_activity_event_end_on', true ),
+					)
+				);
+
+				woocommerce_wp_text_input(
+					array(
+						'id'            => '_simple_nfe_activity_event_code',
+						'label'         => __( 'Event code (activityEvent.code)', 'woo-nfe' ),
+						'wrapper_class' => 'hide_if_variable',
+						'desc_tip'      => 'true',
+						'description'   => __( 'Optional free-text code identifying the activity event.', 'woo-nfe' ),
+						'value'         => get_post_meta( $post_id, '_simple_nfe_activity_event_code', true ),
+					)
+				);
+
+				woocommerce_wp_text_input(
+					array(
+						'id'            => '_simple_nfe_activity_event_address_country',
+						'label'         => __( 'Event country (activityEvent.address.country)', 'woo-nfe' ),
+						'wrapper_class' => 'hide_if_variable',
+						'desc_tip'      => 'true',
+						'description'   => __( 'Country where the event takes place (e.g. BRA).', 'woo-nfe' ),
+						'value'         => get_post_meta( $post_id, '_simple_nfe_activity_event_address_country', true ),
+					)
+				);
+
+				woocommerce_wp_text_input(
+					array(
+						'id'            => '_simple_nfe_activity_event_address_postal_code',
+						'label'         => __( 'Event postal code (activityEvent.address.postalCode)', 'woo-nfe' ),
+						'wrapper_class' => 'hide_if_variable',
+						'desc_tip'      => 'true',
+						'description'   => __( 'Postal/ZIP code of the event address.', 'woo-nfe' ),
+						'value'         => get_post_meta( $post_id, '_simple_nfe_activity_event_address_postal_code', true ),
+					)
+				);
+
+				woocommerce_wp_text_input(
+					array(
+						'id'            => '_simple_nfe_activity_event_address_street',
+						'label'         => __( 'Event street (activityEvent.address.street)', 'woo-nfe' ),
+						'wrapper_class' => 'hide_if_variable',
+						'desc_tip'      => 'true',
+						'description'   => __( 'Street name of the event address.', 'woo-nfe' ),
+						'value'         => get_post_meta( $post_id, '_simple_nfe_activity_event_address_street', true ),
+					)
+				);
+
+				woocommerce_wp_text_input(
+					array(
+						'id'            => '_simple_nfe_activity_event_address_number',
+						'label'         => __( 'Event number (activityEvent.address.number)', 'woo-nfe' ),
+						'wrapper_class' => 'hide_if_variable',
+						'desc_tip'      => 'true',
+						'description'   => __( 'Street number of the event address.', 'woo-nfe' ),
+						'value'         => get_post_meta( $post_id, '_simple_nfe_activity_event_address_number', true ),
+					)
+				);
+
+				woocommerce_wp_text_input(
+					array(
+						'id'            => '_simple_nfe_activity_event_address_district',
+						'label'         => __( 'Event district (activityEvent.address.district)', 'woo-nfe' ),
+						'wrapper_class' => 'hide_if_variable',
+						'desc_tip'      => 'true',
+						'description'   => __( 'District/neighbourhood of the event address.', 'woo-nfe' ),
+						'value'         => get_post_meta( $post_id, '_simple_nfe_activity_event_address_district', true ),
+					)
+				);
+
+				woocommerce_wp_text_input(
+					array(
+						'id'            => '_simple_nfe_activity_event_address_state',
+						'label'         => __( 'Event state (activityEvent.address.state)', 'woo-nfe' ),
+						'wrapper_class' => 'hide_if_variable',
+						'desc_tip'      => 'true',
+						'description'   => __( 'State code of the event address (e.g. SP).', 'woo-nfe' ),
+						'value'         => get_post_meta( $post_id, '_simple_nfe_activity_event_address_state', true ),
+					)
+				);
+
+				woocommerce_wp_text_input(
+					array(
+						'id'            => '_simple_nfe_activity_event_address_city_code',
+						'label'         => __( 'Event city code (activityEvent.address.city.code)', 'woo-nfe' ),
+						'wrapper_class' => 'hide_if_variable',
+						'desc_tip'      => 'true',
+						'description'   => __( 'IBGE city code of the event address.', 'woo-nfe' ),
+						'value'         => get_post_meta( $post_id, '_simple_nfe_activity_event_address_city_code', true ),
+					)
+				);
+
 				woocommerce_wp_textarea_input(
 					array(
 						'id'            => '_simple_nfe_product_desc',
@@ -264,6 +385,20 @@ if ( ! class_exists( 'WC_NFe_Admin' ) ) {
 			$rtc_operation_indicator = isset( $safe_post['_simple_nfe_rtc_operation_indicator'] ) ? sanitize_text_field( $safe_post['_simple_nfe_rtc_operation_indicator'] ) : '';
 			$rtc_class_code          = isset( $safe_post['_simple_nfe_rtc_class_code'] ) ? sanitize_text_field( $safe_post['_simple_nfe_rtc_class_code'] ) : '';
 			$nfe_product_description = isset( $safe_post['_simple_nfe_product_desc'] ) ? sanitize_text_field( $safe_post['_simple_nfe_product_desc'] ) : '';
+
+			// activityEvent fields.
+			$activity_event_name          = isset( $safe_post['_simple_nfe_activity_event_name'] ) ? sanitize_text_field( $safe_post['_simple_nfe_activity_event_name'] ) : '';
+			$activity_event_begin_on      = isset( $safe_post['_simple_nfe_activity_event_begin_on'] ) ? sanitize_text_field( $safe_post['_simple_nfe_activity_event_begin_on'] ) : '';
+			$activity_event_end_on        = isset( $safe_post['_simple_nfe_activity_event_end_on'] ) ? sanitize_text_field( $safe_post['_simple_nfe_activity_event_end_on'] ) : '';
+			$activity_event_code          = isset( $safe_post['_simple_nfe_activity_event_code'] ) ? sanitize_text_field( $safe_post['_simple_nfe_activity_event_code'] ) : '';
+			$activity_event_addr_country  = isset( $safe_post['_simple_nfe_activity_event_address_country'] ) ? sanitize_text_field( $safe_post['_simple_nfe_activity_event_address_country'] ) : '';
+			$activity_event_addr_postal   = isset( $safe_post['_simple_nfe_activity_event_address_postal_code'] ) ? sanitize_text_field( $safe_post['_simple_nfe_activity_event_address_postal_code'] ) : '';
+			$activity_event_addr_street   = isset( $safe_post['_simple_nfe_activity_event_address_street'] ) ? sanitize_text_field( $safe_post['_simple_nfe_activity_event_address_street'] ) : '';
+			$activity_event_addr_number   = isset( $safe_post['_simple_nfe_activity_event_address_number'] ) ? sanitize_text_field( $safe_post['_simple_nfe_activity_event_address_number'] ) : '';
+			$activity_event_addr_district = isset( $safe_post['_simple_nfe_activity_event_address_district'] ) ? sanitize_text_field( $safe_post['_simple_nfe_activity_event_address_district'] ) : '';
+			$activity_event_addr_state    = isset( $safe_post['_simple_nfe_activity_event_address_state'] ) ? sanitize_text_field( $safe_post['_simple_nfe_activity_event_address_state'] ) : '';
+			$activity_event_addr_city     = isset( $safe_post['_simple_nfe_activity_event_address_city_code'] ) ? sanitize_text_field( $safe_post['_simple_nfe_activity_event_address_city_code'] ) : '';
+
 			// Text Field - City Service Code.
 			update_post_meta( $post_id, '_simple_cityservicecode', esc_attr( $city_service_code ) );
 
@@ -274,6 +409,19 @@ if ( ! class_exists( 'WC_NFe_Admin' ) ) {
 			update_post_meta( $post_id, '_simple_nfe_rtc_nbs_code', esc_attr( $rtc_nbs_code ) );
 			update_post_meta( $post_id, '_simple_nfe_rtc_operation_indicator', esc_attr( $rtc_operation_indicator ) );
 			update_post_meta( $post_id, '_simple_nfe_rtc_class_code', esc_attr( $rtc_class_code ) );
+
+			// Text Fields - activityEvent.
+			update_post_meta( $post_id, '_simple_nfe_activity_event_name', esc_attr( $activity_event_name ) );
+			update_post_meta( $post_id, '_simple_nfe_activity_event_begin_on', esc_attr( $activity_event_begin_on ) );
+			update_post_meta( $post_id, '_simple_nfe_activity_event_end_on', esc_attr( $activity_event_end_on ) );
+			update_post_meta( $post_id, '_simple_nfe_activity_event_code', esc_attr( $activity_event_code ) );
+			update_post_meta( $post_id, '_simple_nfe_activity_event_address_country', esc_attr( $activity_event_addr_country ) );
+			update_post_meta( $post_id, '_simple_nfe_activity_event_address_postal_code', esc_attr( $activity_event_addr_postal ) );
+			update_post_meta( $post_id, '_simple_nfe_activity_event_address_street', esc_attr( $activity_event_addr_street ) );
+			update_post_meta( $post_id, '_simple_nfe_activity_event_address_number', esc_attr( $activity_event_addr_number ) );
+			update_post_meta( $post_id, '_simple_nfe_activity_event_address_district', esc_attr( $activity_event_addr_district ) );
+			update_post_meta( $post_id, '_simple_nfe_activity_event_address_state', esc_attr( $activity_event_addr_state ) );
+			update_post_meta( $post_id, '_simple_nfe_activity_event_address_city_code', esc_attr( $activity_event_addr_city ) );
 
 			// TextArea Field - Product Description.
 			update_post_meta( $post_id, '_simple_nfe_product_desc', esc_html( $nfe_product_description ) );
@@ -340,6 +488,116 @@ if ( ! class_exists( 'WC_NFe_Admin' ) ) {
 				)
 			);
 
+			woocommerce_wp_text_input(
+				array(
+					'id'          => '_nfe_activity_event_name[' . $product_id . ']',
+					'label'       => __( 'Event name (activityEvent.name)', 'woo-nfe' ),
+					'desc_tip'    => 'true',
+					'description' => __( 'Name of the activity event. When filled, the activityEvent block will be included in the invoice payload.', 'woo-nfe' ),
+					'value'       => get_post_meta( $product_id, '_nfe_activity_event_name', true ),
+				)
+			);
+
+			woocommerce_wp_text_input(
+				array(
+					'id'          => '_nfe_activity_event_begin_on[' . $product_id . ']',
+					'label'       => __( 'Event start (activityEvent.beginOn)', 'woo-nfe' ),
+					'desc_tip'    => 'true',
+					'description' => __( 'Start date/time of the activity event (ISO 8601, e.g. 2025-07-01T09:00:00).', 'woo-nfe' ),
+					'value'       => get_post_meta( $product_id, '_nfe_activity_event_begin_on', true ),
+				)
+			);
+
+			woocommerce_wp_text_input(
+				array(
+					'id'          => '_nfe_activity_event_end_on[' . $product_id . ']',
+					'label'       => __( 'Event end (activityEvent.endOn)', 'woo-nfe' ),
+					'desc_tip'    => 'true',
+					'description' => __( 'End date/time of the activity event (ISO 8601, e.g. 2025-07-01T18:00:00).', 'woo-nfe' ),
+					'value'       => get_post_meta( $product_id, '_nfe_activity_event_end_on', true ),
+				)
+			);
+
+			woocommerce_wp_text_input(
+				array(
+					'id'          => '_nfe_activity_event_code[' . $product_id . ']',
+					'label'       => __( 'Event code (activityEvent.code)', 'woo-nfe' ),
+					'desc_tip'    => 'true',
+					'description' => __( 'Optional free-text code identifying the activity event.', 'woo-nfe' ),
+					'value'       => get_post_meta( $product_id, '_nfe_activity_event_code', true ),
+				)
+			);
+
+			woocommerce_wp_text_input(
+				array(
+					'id'          => '_nfe_activity_event_address_country[' . $product_id . ']',
+					'label'       => __( 'Event country (activityEvent.address.country)', 'woo-nfe' ),
+					'desc_tip'    => 'true',
+					'description' => __( 'Country where the event takes place (e.g. BRA).', 'woo-nfe' ),
+					'value'       => get_post_meta( $product_id, '_nfe_activity_event_address_country', true ),
+				)
+			);
+
+			woocommerce_wp_text_input(
+				array(
+					'id'          => '_nfe_activity_event_address_postal_code[' . $product_id . ']',
+					'label'       => __( 'Event postal code (activityEvent.address.postalCode)', 'woo-nfe' ),
+					'desc_tip'    => 'true',
+					'description' => __( 'Postal/ZIP code of the event address.', 'woo-nfe' ),
+					'value'       => get_post_meta( $product_id, '_nfe_activity_event_address_postal_code', true ),
+				)
+			);
+
+			woocommerce_wp_text_input(
+				array(
+					'id'          => '_nfe_activity_event_address_street[' . $product_id . ']',
+					'label'       => __( 'Event street (activityEvent.address.street)', 'woo-nfe' ),
+					'desc_tip'    => 'true',
+					'description' => __( 'Street name of the event address.', 'woo-nfe' ),
+					'value'       => get_post_meta( $product_id, '_nfe_activity_event_address_street', true ),
+				)
+			);
+
+			woocommerce_wp_text_input(
+				array(
+					'id'          => '_nfe_activity_event_address_number[' . $product_id . ']',
+					'label'       => __( 'Event number (activityEvent.address.number)', 'woo-nfe' ),
+					'desc_tip'    => 'true',
+					'description' => __( 'Street number of the event address.', 'woo-nfe' ),
+					'value'       => get_post_meta( $product_id, '_nfe_activity_event_address_number', true ),
+				)
+			);
+
+			woocommerce_wp_text_input(
+				array(
+					'id'          => '_nfe_activity_event_address_district[' . $product_id . ']',
+					'label'       => __( 'Event district (activityEvent.address.district)', 'woo-nfe' ),
+					'desc_tip'    => 'true',
+					'description' => __( 'District/neighbourhood of the event address.', 'woo-nfe' ),
+					'value'       => get_post_meta( $product_id, '_nfe_activity_event_address_district', true ),
+				)
+			);
+
+			woocommerce_wp_text_input(
+				array(
+					'id'          => '_nfe_activity_event_address_state[' . $product_id . ']',
+					'label'       => __( 'Event state (activityEvent.address.state)', 'woo-nfe' ),
+					'desc_tip'    => 'true',
+					'description' => __( 'State code of the event address (e.g. SP).', 'woo-nfe' ),
+					'value'       => get_post_meta( $product_id, '_nfe_activity_event_address_state', true ),
+				)
+			);
+
+			woocommerce_wp_text_input(
+				array(
+					'id'          => '_nfe_activity_event_address_city_code[' . $product_id . ']',
+					'label'       => __( 'Event city code (activityEvent.address.city.code)', 'woo-nfe' ),
+					'desc_tip'    => 'true',
+					'description' => __( 'IBGE city code of the event address.', 'woo-nfe' ),
+					'value'       => get_post_meta( $product_id, '_nfe_activity_event_address_city_code', true ),
+				)
+			);
+
 			woocommerce_wp_textarea_input(
 				array(
 					'id'          => '_nfe_product_variation_desc[' . $product_id . ']',
@@ -366,6 +624,21 @@ if ( ! class_exists( 'WC_NFe_Admin' ) ) {
 			$rtc_class_code             = ( isset( $safe_post['_nfe_rtc_class_code'] ) && isset( $safe_post['_nfe_rtc_class_code'][ intval( $post_id ) ] ) ) ? sanitize_text_field( $safe_post['_nfe_rtc_class_code'][ intval( $post_id ) ] ) : '';
 			$nfe_product_variation_desc = ( isset( $safe_post['_nfe_product_variation_desc'] ) && isset( $safe_post['_nfe_product_variation_desc'][ intval( $post_id ) ] ) ) ? sanitize_text_field( $safe_post['_nfe_product_variation_desc'][ intval( $post_id ) ] ) : '';
 
+			$pid = intval( $post_id );
+
+			// activityEvent variation fields.
+			$activity_event_name          = ( isset( $safe_post['_nfe_activity_event_name'][ $pid ] ) ) ? sanitize_text_field( $safe_post['_nfe_activity_event_name'][ $pid ] ) : '';
+			$activity_event_begin_on      = ( isset( $safe_post['_nfe_activity_event_begin_on'][ $pid ] ) ) ? sanitize_text_field( $safe_post['_nfe_activity_event_begin_on'][ $pid ] ) : '';
+			$activity_event_end_on        = ( isset( $safe_post['_nfe_activity_event_end_on'][ $pid ] ) ) ? sanitize_text_field( $safe_post['_nfe_activity_event_end_on'][ $pid ] ) : '';
+			$activity_event_code          = ( isset( $safe_post['_nfe_activity_event_code'][ $pid ] ) ) ? sanitize_text_field( $safe_post['_nfe_activity_event_code'][ $pid ] ) : '';
+			$activity_event_addr_country  = ( isset( $safe_post['_nfe_activity_event_address_country'][ $pid ] ) ) ? sanitize_text_field( $safe_post['_nfe_activity_event_address_country'][ $pid ] ) : '';
+			$activity_event_addr_postal   = ( isset( $safe_post['_nfe_activity_event_address_postal_code'][ $pid ] ) ) ? sanitize_text_field( $safe_post['_nfe_activity_event_address_postal_code'][ $pid ] ) : '';
+			$activity_event_addr_street   = ( isset( $safe_post['_nfe_activity_event_address_street'][ $pid ] ) ) ? sanitize_text_field( $safe_post['_nfe_activity_event_address_street'][ $pid ] ) : '';
+			$activity_event_addr_number   = ( isset( $safe_post['_nfe_activity_event_address_number'][ $pid ] ) ) ? sanitize_text_field( $safe_post['_nfe_activity_event_address_number'][ $pid ] ) : '';
+			$activity_event_addr_district = ( isset( $safe_post['_nfe_activity_event_address_district'][ $pid ] ) ) ? sanitize_text_field( $safe_post['_nfe_activity_event_address_district'][ $pid ] ) : '';
+			$activity_event_addr_state    = ( isset( $safe_post['_nfe_activity_event_address_state'][ $pid ] ) ) ? sanitize_text_field( $safe_post['_nfe_activity_event_address_state'][ $pid ] ) : '';
+			$activity_event_addr_city     = ( isset( $safe_post['_nfe_activity_event_address_city_code'][ $pid ] ) ) ? sanitize_text_field( $safe_post['_nfe_activity_event_address_city_code'][ $pid ] ) : '';
+
 			// Text Field - City Service Code.
 			update_post_meta( $post_id, '_cityservicecode', esc_attr( $city_service_code ) );
 
@@ -376,6 +649,19 @@ if ( ! class_exists( 'WC_NFe_Admin' ) ) {
 			update_post_meta( $post_id, '_nfe_rtc_nbs_code', esc_attr( $rtc_nbs_code ) );
 			update_post_meta( $post_id, '_nfe_rtc_operation_indicator', esc_attr( $rtc_operation_indicator ) );
 			update_post_meta( $post_id, '_nfe_rtc_class_code', esc_attr( $rtc_class_code ) );
+
+			// Text Fields - activityEvent.
+			update_post_meta( $post_id, '_nfe_activity_event_name', esc_attr( $activity_event_name ) );
+			update_post_meta( $post_id, '_nfe_activity_event_begin_on', esc_attr( $activity_event_begin_on ) );
+			update_post_meta( $post_id, '_nfe_activity_event_end_on', esc_attr( $activity_event_end_on ) );
+			update_post_meta( $post_id, '_nfe_activity_event_code', esc_attr( $activity_event_code ) );
+			update_post_meta( $post_id, '_nfe_activity_event_address_country', esc_attr( $activity_event_addr_country ) );
+			update_post_meta( $post_id, '_nfe_activity_event_address_postal_code', esc_attr( $activity_event_addr_postal ) );
+			update_post_meta( $post_id, '_nfe_activity_event_address_street', esc_attr( $activity_event_addr_street ) );
+			update_post_meta( $post_id, '_nfe_activity_event_address_number', esc_attr( $activity_event_addr_number ) );
+			update_post_meta( $post_id, '_nfe_activity_event_address_district', esc_attr( $activity_event_addr_district ) );
+			update_post_meta( $post_id, '_nfe_activity_event_address_state', esc_attr( $activity_event_addr_state ) );
+			update_post_meta( $post_id, '_nfe_activity_event_address_city_code', esc_attr( $activity_event_addr_city ) );
 
 			// TextArea Field - Product Variation Description.
 			update_post_meta( $post_id, '_nfe_product_variation_desc', esc_html( $nfe_product_variation_desc ) );

--- a/includes/admin/class-api.php
+++ b/includes/admin/class-api.php
@@ -253,7 +253,8 @@ if ( ! class_exists( 'NFe_Woo' ) ) {
 				'address'          => $address,
 			);
 
-			$rtc_info = $this->rtc_fields_info( $order_id );
+			$rtc_info       = $this->rtc_fields_info( $order_id );
+			$activity_event = $this->activity_event_info( $order_id );
 
 			$data = array(
 				'cityServiceCode'    => $this->city_service_info( 'code', $order_id ),
@@ -264,6 +265,7 @@ if ( ! class_exists( 'NFe_Woo' ) ) {
 				'externalId'         => 'WOO-NFE-' . $order_id,
 				'nbsCode'            => $rtc_info['nbsCode'],
 				'ibsCbs'             => $rtc_info['ibsCbs'],
+				'activityEvent'      => ! empty( $activity_event ) ? $activity_event : null,
 			);
 
 			$data = apply_filters( 'woo_nfe_rtc_payload', $data, $order_id, $order );
@@ -602,6 +604,98 @@ if ( ! class_exists( 'NFe_Woo' ) ) {
 				'nbsCode' => $nbs_code,
 				'ibsCbs'  => $ibs_cbs,
 			);
+		}
+
+		/**
+		 * Collects activityEvent fields from the first order item that has event name set.
+		 * Precedence: variation meta > product meta. No global fallback.
+		 *
+		 * @param int $order_id order ID.
+		 *
+		 * @return array activityEvent array ready for payload, or empty array.
+		 */
+		protected function activity_event_info( $order_id ) {
+			$order = nfe_wc_get_order( $order_id );
+
+			if ( 0 >= count( $order->get_items() ) ) {
+				return array();
+			}
+
+			foreach ( $order->get_items() as $item ) {
+				$product_id   = $item['product_id'];
+				$variation_id = $item['variation_id'];
+
+				if ( $variation_id ) {
+					$name     = get_post_meta( $variation_id, '_nfe_activity_event_name', true );
+					$begin_on = get_post_meta( $variation_id, '_nfe_activity_event_begin_on', true );
+					$end_on   = get_post_meta( $variation_id, '_nfe_activity_event_end_on', true );
+					$code     = get_post_meta( $variation_id, '_nfe_activity_event_code', true );
+					$country  = get_post_meta( $variation_id, '_nfe_activity_event_address_country', true );
+					$postal   = get_post_meta( $variation_id, '_nfe_activity_event_address_postal_code', true );
+					$street   = get_post_meta( $variation_id, '_nfe_activity_event_address_street', true );
+					$number   = get_post_meta( $variation_id, '_nfe_activity_event_address_number', true );
+					$district = get_post_meta( $variation_id, '_nfe_activity_event_address_district', true );
+					$state    = get_post_meta( $variation_id, '_nfe_activity_event_address_state', true );
+					$city     = get_post_meta( $variation_id, '_nfe_activity_event_address_city_code', true );
+
+					// Fall back to parent product when variation has no name.
+					if ( empty( $name ) ) {
+						$name     = get_post_meta( $product_id, '_simple_nfe_activity_event_name', true );
+						$begin_on = get_post_meta( $product_id, '_simple_nfe_activity_event_begin_on', true );
+						$end_on   = get_post_meta( $product_id, '_simple_nfe_activity_event_end_on', true );
+						$code     = get_post_meta( $product_id, '_simple_nfe_activity_event_code', true );
+						$country  = get_post_meta( $product_id, '_simple_nfe_activity_event_address_country', true );
+						$postal   = get_post_meta( $product_id, '_simple_nfe_activity_event_address_postal_code', true );
+						$street   = get_post_meta( $product_id, '_simple_nfe_activity_event_address_street', true );
+						$number   = get_post_meta( $product_id, '_simple_nfe_activity_event_address_number', true );
+						$district = get_post_meta( $product_id, '_simple_nfe_activity_event_address_district', true );
+						$state    = get_post_meta( $product_id, '_simple_nfe_activity_event_address_state', true );
+						$city     = get_post_meta( $product_id, '_simple_nfe_activity_event_address_city_code', true );
+					}
+				} else {
+					$name     = get_post_meta( $product_id, '_simple_nfe_activity_event_name', true );
+					$begin_on = get_post_meta( $product_id, '_simple_nfe_activity_event_begin_on', true );
+					$end_on   = get_post_meta( $product_id, '_simple_nfe_activity_event_end_on', true );
+					$code     = get_post_meta( $product_id, '_simple_nfe_activity_event_code', true );
+					$country  = get_post_meta( $product_id, '_simple_nfe_activity_event_address_country', true );
+					$postal   = get_post_meta( $product_id, '_simple_nfe_activity_event_address_postal_code', true );
+					$street   = get_post_meta( $product_id, '_simple_nfe_activity_event_address_street', true );
+					$number   = get_post_meta( $product_id, '_simple_nfe_activity_event_address_number', true );
+					$district = get_post_meta( $product_id, '_simple_nfe_activity_event_address_district', true );
+					$state    = get_post_meta( $product_id, '_simple_nfe_activity_event_address_state', true );
+					$city     = get_post_meta( $product_id, '_simple_nfe_activity_event_address_city_code', true );
+				}
+
+				if ( empty( $name ) ) {
+					continue;
+				}
+
+				$address = array_filter(
+					array(
+						'country'    => $country,
+						'postalCode' => $postal,
+						'street'     => $street,
+						'number'     => $number,
+						'district'   => $district,
+						'state'      => $state,
+						'city'       => array_filter(
+							array( 'code' => $city )
+						),
+					)
+				);
+
+				return array_filter(
+					array(
+						'name'    => $name,
+						'beginOn' => $begin_on,
+						'endOn'   => $end_on,
+						'code'    => $code,
+						'address' => $address ?: null,
+					)
+				);
+			}
+
+			return array();
 		}
 
 		/**

--- a/openspec/changes/adequar-campos-rtc-reforma-tributaria/design.md
+++ b/openspec/changes/adequar-campos-rtc-reforma-tributaria/design.md
@@ -14,7 +14,8 @@ Restrições relevantes:
 
 ## Tracking
 
-- Issue GitHub: https://github.com/nfe/woo-nfe/issues/84
+- Issue GitHub (RTC Fase 1): https://github.com/nfe/woo-nfe/issues/84
+- Issue GitHub (activityEvent): https://github.com/nfe/woo-nfe/issues/87
 
 ## Goals / Non-Goals
 
@@ -28,6 +29,7 @@ Restrições relevantes:
 - Implementar motor fiscal automático para inferir operationIndicator e classCode a partir de regras tributárias completas.
 - Cobrir todos os subgrupos avançados de ibsCbs na primeira entrega (ex.: creditTransfer, presumedCredits, governmentPurchase).
 - Alterar fluxos de webhook, cancelamento ou consulta além do necessário para emissão.
+- Implementar fallback global para activityEvent (dados do evento são intrinsecamente por produto/serviço, sem default corporativo aplicável).
 
 ## Decisions
 
@@ -108,6 +110,19 @@ Restrições relevantes:
 4. Definir data de corte para migração recomendada ao perfil Estrito, baseada em métricas de saneamento cadastral.
 5. Monitorar erros/alertas de emissão e ajustar regras condicionais em iterações curtas.
 6. Rollback: rebaixar perfil para Compatível em caso de incidente operacional relevante.
+
+9. Modelo de dados para activityEvent sem fallback global.
+- Decisão: coletar os campos de activityEvent (name, beginOn, endOn, Code, address.*) apenas em produto simples e variação, com precedência variação > produto. Sem nível de configuração global.
+- Racional: o endereço do evento e suas datas são específicos do produto/serviço comercializado (ex: ingresso de show). Não existe default corporativo de "endereço de evento" que faça sentido para todas as emissões. Segue o mesmo padrão de campos explícitos já usado para os demais campos fiscais.
+- Alternativas consideradas:
+  - Incluir configuração global de activityEvent: criaria false sense of security — um endereço global de evento seria aplicado a produtos sem relação com aquele evento.
+  - Coletar activityEvent por pedido no admin do pedido (WC order): válido para operação manual pontual, mas inconsistente com o ciclo de cadastro de produto e não escala para volumes maiores. Descartado em favor do padrão produto/variação já estabelecido.
+
+10. Campo name como gatilho de inclusão do bloco.
+- Decisão: incluir o bloco activityEvent no payload somente quando name estiver preenchido. Campos parciais de address são enviados só se não vazios (array_filter).
+- Racional: name identifica o evento de forma inequívoca. Bloco incompleto sem name não agrega semântica fiscal. Consistente com o comportamento dos demais grupos opcionais já implementados.
+- Alternativas consideradas:
+  - Exigir name + pelo menos um campo de address: mais restritivo, mas aumenta fricção para casos simples (evento sem endereço detalhado cadastrado).
 
 ## Open Questions
 

--- a/openspec/changes/adequar-campos-rtc-reforma-tributaria/specs/nfse-rtc-activity-event/spec.md
+++ b/openspec/changes/adequar-campos-rtc-reforma-tributaria/specs/nfse-rtc-activity-event/spec.md
@@ -1,0 +1,43 @@
+## ADDED Requirements
+
+### Requirement: Coleta e persistência do grupo activityEvent por produto
+O sistema MUST coletar e persistir os campos do grupo activityEvent no produto simples e na variação, sem fallback para configuração global.
+
+#### Scenario: Campos de activityEvent em produto simples
+- **WHEN** o operador preencher os campos de activityEvent no painel de edição do produto simples
+- **THEN** o sistema MUST salvar name, beginOn, endOn, Code e os subcampos de address como meta do produto com sanitização adequada
+
+#### Scenario: Campos de activityEvent em variação
+- **WHEN** o operador preencher os campos de activityEvent no painel de edição da variação
+- **THEN** o sistema MUST salvar name, beginOn, endOn, Code e os subcampos de address como meta da variação com sanitização adequada
+
+#### Scenario: Precedência variação sobre produto para activityEvent
+- **WHEN** um item do pedido for variação e existir name preenchido na variação
+- **THEN** o sistema MUST usar os dados de activityEvent da variação no payload de emissão
+
+#### Scenario: Fallback para produto simples em activityEvent
+- **WHEN** não existir name preenchido na variação e existir name preenchido no produto
+- **THEN** o sistema MUST usar os dados de activityEvent do produto no payload de emissão
+
+#### Scenario: Ausência de activityEvent no produto e na variação
+- **WHEN** não existir name preenchido nem na variação nem no produto de nenhum item do pedido
+- **THEN** o sistema MUST omitir o bloco activityEvent do payload de emissão
+
+### Requirement: Inclusão do grupo activityEvent no payload de emissão
+O sistema MUST incluir o grupo activityEvent no payload RTC de NFS-e quando o campo name estiver preenchido no produto ou variação de pelo menos um item do pedido.
+
+#### Scenario: Emissão com activityEvent completo
+- **WHEN** o produto ou variação do pedido tiver name, beginOn, endOn, Code e address preenchidos
+- **THEN** o payload MUST conter o bloco activityEvent com todos os campos informados antes do envio para a API
+
+#### Scenario: Emissão com activityEvent parcial
+- **WHEN** o produto ou variação do pedido tiver name preenchido e demais campos parcialmente preenchidos
+- **THEN** o payload MUST conter o bloco activityEvent apenas com os campos não vazios, omitindo subcampos ausentes
+
+#### Scenario: Emissão sem activityEvent
+- **WHEN** nenhum item do pedido tiver name de activityEvent preenchido
+- **THEN** o payload MUST NOT conter o bloco activityEvent
+
+#### Scenario: Emissão sem regressão nos campos existentes
+- **WHEN** o pedido não tiver activityEvent configurado
+- **THEN** o sistema MUST emitir normalmente com nbsCode, ibsCbs e demais campos sem alteração de comportamento

--- a/openspec/changes/adequar-campos-rtc-reforma-tributaria/tasks.md
+++ b/openspec/changes/adequar-campos-rtc-reforma-tributaria/tasks.md
@@ -1,6 +1,7 @@
 ## Tracking
 
-- Issue GitHub: https://github.com/nfe/woo-nfe/issues/84
+- Issue GitHub (RTC Fase 1): https://github.com/nfe/woo-nfe/issues/84
+- Issue GitHub (activityEvent): https://github.com/nfe/woo-nfe/issues/87
 
 ## 1. Preparação e mapeamento fiscal
 
@@ -40,3 +41,24 @@
 - [x] 6.3 Revisar textos de ajuda no admin para orientar preenchimento fiscal
 - [x] 6.4 Atualizar documentação de uso e checklist de ativação da reforma tributária
 - [x] 6.5 Documentar limitação de UI da fase 1 para recipient/destinationIndicator e instrução de uso via integração
+
+## 7. activityEvent — Campos administrativos e persistência
+
+- [x] 7.1 Adicionar campos de activityEvent (name, beginOn, endOn, Code, address.*) em produto simples na aba NFe do produto
+- [x] 7.2 Adicionar campos de activityEvent em variação com os mesmos subcampos
+- [x] 7.3 Implementar save de produto simples e variação com sanitização (sanitize_text_field para textos, sanitize_key para datetime)
+- [x] 7.4 Garantir precedência variação > produto na leitura dos campos de activityEvent por item do pedido
+
+## 8. activityEvent — Montagem de payload
+
+- [x] 8.1 Implementar método activity_event_info( $order_id ) que itera os itens e retorna o primeiro produto/variação com name preenchido
+- [x] 8.2 Incluir bloco activityEvent no array de dados do payload RTC, condicionado à presença de name
+- [x] 8.3 Garantir que subcampos vazios do address sejam removidos via array_filter antes do envio
+- [x] 8.4 Validar ausência de regressão nos campos nbsCode, ibsCbs e fluxo legado
+
+## 9. Verificação funcional — activityEvent
+
+- [x] 9.1 Validar cenário: produto com activityEvent completo — payload contém bloco com todos os campos
+- [x] 9.2 Validar cenário: produto com activityEvent parcial (só name) — payload contém bloco apenas com name
+- [x] 9.3 Validar cenário: pedido sem activityEvent — bloco ausente do payload sem regressão
+- [x] 9.4 Validar precedência: variação com activityEvent prevalece sobre produto com activityEvent diferente


### PR DESCRIPTION
## Resumo

Implementa coleta, persistência e envio do grupo `activityEvent` da Reforma Tributária Complementar (RTC) conforme spec [`nfse-rtc-activity-event`](openspec/changes/adequar-campos-rtc-reforma-tributaria/specs/nfse-rtc-activity-event/spec.md).

Completa as tarefas 7.1–9.4 do change `adequar-campos-rtc-reforma-tributaria`, encerrando todas as 33 tarefas do change (21 da Fase 1 RTC + 12 do activityEvent).

Closes #87

---

## Campos adicionados

### Produto simples — aba WooCommerce NFe

| Meta key | Campo da API |
|---|---|
| `_simple_nfe_activity_event_name` | `activityEvent.name` — **gatilho de inclusão do bloco** |
| `_simple_nfe_activity_event_begin_on` | `activityEvent.beginOn` |
| `_simple_nfe_activity_event_end_on` | `activityEvent.endOn` |
| `_simple_nfe_activity_event_code` | `activityEvent.code` |
| `_simple_nfe_activity_event_address_country` | `activityEvent.address.country` |
| `_simple_nfe_activity_event_address_postal_code` | `activityEvent.address.postalCode` |
| `_simple_nfe_activity_event_address_street` | `activityEvent.address.street` |
| `_simple_nfe_activity_event_address_number` | `activityEvent.address.number` |
| `_simple_nfe_activity_event_address_district` | `activityEvent.address.district` |
| `_simple_nfe_activity_event_address_state` | `activityEvent.address.state` |
| `_simple_nfe_activity_event_address_city_code` | `activityEvent.address.city.code` |

### Variação de produto

Mesmos campos com prefixo `_nfe_activity_event_*` e indexação por `product_id`.

---

## Comportamento de payload

- **Gatilho**: `name` preenchido em qualquer item do pedido → bloco `activityEvent` incluído  
- **Precedência**: variação → produto (sem fallback global — Decisão 9)  
- **Campos parciais**: `array_filter` aninhado remove subcampos vazios de `address`  
- **Ausência de `name`**: bloco completamente omitido, sem regressão em `nbsCode`/`ibsCbs`

---

## Arquivos modificados

- `includes/admin/class-admin.php` — `product_data_fields()`, `variation_fields()`, `product_data_fields_save()`, `save_variations_fields()`
- `includes/admin/class-api.php` — novo método `activity_event_info($order_id)`, `datainvoice_body()` atualizado

## OpenSpec

- `tasks.md` — tarefas 7.1–9.4 marcadas como concluídas
- `design.md` — decisões 9 e 10 registradas
- `specs/nfse-rtc-activity-event/spec.md` — spec adicionada ao change